### PR TITLE
Codegen HTML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .Rhistory
 .RData
 .Ruserdata
-.Rproj
+*.Rproj
 
 # ignore all created docs expect gallery page
 !docs/articles/pkgnet-gallery.html

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ and then add a new entry to the list above that line for your package. (Note the
     )
 ```
 
-OPTIONAL: If you have the knitr, htmltools, and glue packages installed, you should be able to test that everything runs through correctly by hitting "Knit" if you're using RStudio.
+OPTIONAL: If you have the knitr and glue packages installed, you should be able to test that everything runs through correctly by hitting "Knit" if you're using RStudio.
 
 #### 4. Submit!
 [Submit a pull request](https://help.github.com/en/articles/creating-a-pull-request)!

--- a/README.md
+++ b/README.md
@@ -33,18 +33,25 @@ If you would like to host your examples on this repository, include their additi
 
 If you have the means and desire to host your exhibits yourself, you are welcome to do that.
 
-#### 3. Add HTML Code (just a little)
-Add html code to [`vignettes/pkgnet-gallery.Rmd`](vignettes/pkgnet-gallery.Rmd) that links to your exhibit (either hosted elsewhere or in this repository) in following this format:
+#### 3. Add your exhibit to the gallery page
 
-```HTML
-<td width="33%">[Your Package Name]<br>
-	<a href="[URL to your package report]">
-		<img width="300" src="[URL to your image]">
-	</a>
-</td>
+Add your exhibit to [`vignettes/pkgnet-gallery.Rmd`](vignettes/pkgnet-gallery.Rmd). Find the line that says 
+
+```
+### ADD NEW EXHIBITS ABOVE THIS LINE ###
 ```
 
-Be sure to keep three (3) exhibits per row at maximum. 
+and then add a new entry to the list above that line for your package. (Note the leading comma---you shouldn't need to touch any other lines.)
+
+```R
+    , list(
+        package_name = "[Your Package Name]"
+        , report_url = "[URL to your package report]"
+        , image_url = "[URL to your image]"
+    )
+```
+
+OPTIONAL: If you have the knitr, htmltools, and glue packages installed, you should be able to test that everything runs through correctly by hitting "Knit" if you're using RStudio.
 
 #### 4. Submit!
 [Submit a pull request](https://help.github.com/en/articles/creating-a-pull-request)!

--- a/docs/articles/pkgnet-gallery.html
+++ b/docs/articles/pkgnet-gallery.html
@@ -82,39 +82,38 @@
 
     
     
-<p>Welcome to the <strong>pkgnet</strong> gallery! Click one any item below to see an example report. Go to the <a href="https://github.com/UptakeOpenSource/pkgnet-gallery">gallery github page</a> to contribute.</p>
-
+<p>Welcome to the <strong>pkgnet</strong> gallery! Click any item below to see an example report. Go to the <a href="https://github.com/UptakeOpenSource/pkgnet-gallery">gallery github page</a> to contribute.</p>
 <table class="table">
-<tr valign="top">
-<td width="33%">bingo<br><a href="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/bingo/bingo.html">
-				<img width="300" src="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/bingo/bingo.png"></a>
-		</td>
-		<td width="33%">data.table<br><a href="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/data_table/data_table.html">
-				<img width="300" src="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/data_table/data_table.png"></a>
-		</td>
-		<td width="33%">ggplot2<br><a href="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/ggplot2/ggplot2.html">
-				<img width="300" src="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/ggplot2/ggplot2.png"></a>
-		</td>
-	</tr>
 <tr>
-<td width="33%">lubridate<br><a href="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/lubridate/lubridate.html">
-				<img width="300" src="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/lubridate/lubridate.png"></a>
-		</td>
-		<td width="33%">pipecleaner<br><a href="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/pipecleaner/pipecleaner.html">
-				<img width="300" src="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/pipecleaner/pipecleaner.png"></a>
-		</td>
-		<td width="33%">pkgnet<br><a href="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/pkgnet/pkgnet.html">
-				<img width="300" src="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/pkgnet/pkgnet.png"></a>
-		</td>
-	</tr>
+<td width="33%" style="text-align:center">bingo<br><a href="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/bingo/bingo.html">
+        <img width="300" src="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/bingo/bingo.png"></a>
+</td>
+<td width="33%" style="text-align:center">data.table<br><a href="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/data_table/data_table.html">
+        <img width="300" src="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/data_table/data_table.png"></a>
+</td>
+<td width="33%" style="text-align:center">ggplot2<br><a href="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/ggplot2/ggplot2.html">
+        <img width="300" src="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/ggplot2/ggplot2.png"></a>
+</td>
+</tr>
 <tr>
-<td width="33%">pkgnet (Vignette)<br><a href="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/pkgnet-vignette/pkgnet-vignette.html">
-				<img width="300" src="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/pkgnet/pkgnet.png"></a>
-		</td>
-		<td width="33%">updraft<br><a href="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/updraft/updraft.html">
-				<img width="300" src="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/updraft/updraft.png"></a>
-		</td>
-	</tr>
+<td width="33%" style="text-align:center">lubridate<br><a href="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/lubridate/lubridate.html">
+        <img width="300" src="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/lubridate/lubridate.png"></a>
+</td>
+<td width="33%" style="text-align:center">pipecleaner<br><a href="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/pipecleaner/pipecleaner.html">
+        <img width="300" src="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/pipecleaner/pipecleaner.png"></a>
+</td>
+<td width="33%" style="text-align:center">pkgnet<br><a href="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/pkgnet/pkgnet.html">
+        <img width="300" src="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/pkgnet/pkgnet.png"></a>
+</td>
+</tr>
+<tr>
+<td width="33%" style="text-align:center">pkgnet (Vignette)<br><a href="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/pkgnet-vignette/pkgnet-vignette.html">
+        <img width="300" src="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/pkgnet/pkgnet.png"></a>
+</td>
+<td width="33%" style="text-align:center">updraft<br><a href="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/updraft/updraft.html">
+        <img width="300" src="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/updraft/updraft.png"></a>
+</td>
+</tr>
 </table>
 </div>
 

--- a/vignettes/pkgnet-gallery.Rmd
+++ b/vignettes/pkgnet-gallery.Rmd
@@ -8,55 +8,112 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-Welcome to the **pkgnet** gallery!   Click one any item below to see an example report.  Go to the [gallery github page](https://github.com/UptakeOpenSource/pkgnet-gallery) to contribute. 
+Welcome to the **pkgnet** gallery!   Click any item below to see an example report.  Go to the [gallery github page](https://github.com/UptakeOpenSource/pkgnet-gallery) to contribute. 
 
-<!--html_preserve-->
-<table>
-	<tr valign="top">
-		<td width="33%">bingo<br>
-			<a href="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/bingo/bingo.html">
-				<img width="300" src="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/bingo/bingo.png">
-			</a>
-		</td>
-		<td width="33%">data.table<br>
-			<a href="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/data_table/data_table.html">
-				<img width="300" src="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/data_table/data_table.png">
-			</a>
-		</td>
-		<td width="33%">ggplot2<br>
-			<a href="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/ggplot2/ggplot2.html">
-				<img width="300" src="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/ggplot2/ggplot2.png">
-			</a>
-		</td>
-	</tr>
-	<tr>
-		<td width="33%">lubridate<br>
-			<a href="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/lubridate/lubridate.html">
-				<img width="300" src="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/lubridate/lubridate.png">
-			</a>
-		</td>
-		<td width="33%">pipecleaner<br>
-			<a href="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/pipecleaner/pipecleaner.html">
-				<img width="300" src="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/pipecleaner/pipecleaner.png">
-			</a>
-		</td>
-		<td width="33%">pkgnet<br>
-			<a href="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/pkgnet/pkgnet.html">
-				<img width="300" src="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/pkgnet/pkgnet.png">
-			</a>
-		</td>
-	</tr>
-	<tr>
-		<td width="33%">pkgnet (Vignette)<br>
-			<a href="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/pkgnet-vignette/pkgnet-vignette.html">
-				<img width="300" src="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/pkgnet/pkgnet.png">
-			</a>
-		</td>
-		<td width="33%">updraft<br>
-			<a href="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/updraft/updraft.html">
-				<img width="300" src="https://uptakeopensource.github.io/pkgnet-gallery/exhibits/updraft/updraft.png">
-			</a>
-		</td>
-	</tr>
-</table>
-<!--/html_preserve-->
+```{r exhibit_data, include = FALSE}
+exhibitsList <- list(
+    list(
+        package_name = "pkgnet"
+        , report_url = "https://uptakeopensource.github.io/pkgnet-gallery/exhibits/pkgnet/pkgnet.html"
+        , image_url = "https://uptakeopensource.github.io/pkgnet-gallery/exhibits/pkgnet/pkgnet.png"
+    )
+    , list(
+        package_name = "pkgnet (Vignette)"
+        , report_url = "https://uptakeopensource.github.io/pkgnet-gallery/exhibits/pkgnet-vignette/pkgnet-vignette.html"
+        , image_url = "https://uptakeopensource.github.io/pkgnet-gallery/exhibits/pkgnet/pkgnet.png"
+    )
+    , list(
+        package_name = "bingo"
+        , report_url = "https://uptakeopensource.github.io/pkgnet-gallery/exhibits/bingo/bingo.html"
+        , image_url = "https://uptakeopensource.github.io/pkgnet-gallery/exhibits/bingo/bingo.png"
+    )
+    , list(
+        package_name = "data.table"
+        , report_url = "https://uptakeopensource.github.io/pkgnet-gallery/exhibits/data_table/data_table.html"
+        , image_url = "https://uptakeopensource.github.io/pkgnet-gallery/exhibits/data_table/data_table.png"
+    )
+    , list(
+        package_name = "ggplot2"
+        , report_url = "https://uptakeopensource.github.io/pkgnet-gallery/exhibits/ggplot2/ggplot2.html"
+        , image_url = "https://uptakeopensource.github.io/pkgnet-gallery/exhibits/ggplot2/ggplot2.png"
+    )
+    , list(
+        package_name = "lubridate"
+        , report_url = "https://uptakeopensource.github.io/pkgnet-gallery/exhibits/lubridate/lubridate.html"
+        , image_url = "https://uptakeopensource.github.io/pkgnet-gallery/exhibits/lubridate/lubridate.png"
+    )
+    , list(
+        package_name = "pipecleaner"
+        , report_url = "https://uptakeopensource.github.io/pkgnet-gallery/exhibits/pipecleaner/pipecleaner.html"
+        , image_url = "https://uptakeopensource.github.io/pkgnet-gallery/exhibits/pipecleaner/pipecleaner.png"
+    )
+    , list(
+        package_name = "updraft"
+        , report_url = "https://uptakeopensource.github.io/pkgnet-gallery/exhibits/updraft/updraft.html"
+        , image_url = "https://uptakeopensource.github.io/pkgnet-gallery/exhibits/updraft/updraft.png"
+    )
+    
+    ### ADD NEW EXHIBITS ABOVE THIS LINE ###
+)
+
+# Sort exhibits alphabetically by name
+exhibitsList <- exhibitsList[order(
+    # Pull out package_name to use with order to reorder
+    vapply(exhibitsList, `[[`, i = "package_name", FUN.VALUE = character(1))
+)]
+```
+
+```{r write_html, include = FALSE}
+
+# Template for one cell in exhibit table, for use with glue
+cellTemplate <- '
+<td width="33%">{package_name}<br>
+    <a href="{report_url}">
+        <img width="300" src="{image_url}">
+    </a>
+</td>
+'
+
+numRows <- ceiling(length(exhibitsList)/3)
+cellToRowMapping <- ceiling(1:length(exhibitsList)/3)
+
+# Generate vector of row html blobs
+rowHTML <- vapply(
+    X = 1:numRows
+    , FUN = function(row) {
+        paste('<tr>'
+              # Paste together cells
+              , paste(
+                  # Generate cell HTML
+                  vapply(
+                    X = exhibitsList[cellToRowMapping == row]
+                    , FUN = function(exh) {
+                        glue::glue(
+                            cellTemplate
+                            , package_name = exh[['package_name']]
+                            , report_url = exh[['report_url']]
+                            , image_url = exh[['image_url']]
+                        )
+                    }
+                    , FUN.VALUE = character(1)
+                  )
+                  , collapse = "\n"
+              )
+              , '</tr>'
+              , sep = '\n'
+        )
+    }
+    , FUN.VALUE = character(1)
+)
+
+tableHTML <- paste(
+    '<table>'
+    , paste(rowHTML, collapse = '\n')
+    , '</table>'
+    , sep = "\n"
+)
+```
+
+```{r html_output, echo = FALSE}
+knitr::asis_output(htmltools::htmlPreserve(tableHTML))
+```

--- a/vignettes/pkgnet-gallery.Rmd
+++ b/vignettes/pkgnet-gallery.Rmd
@@ -56,6 +56,41 @@ exhibitsList <- list(
     ### ADD NEW EXHIBITS ABOVE THIS LINE ###
 )
 
+assertthat::assert_that(
+    all(vapply(
+        X = exhibitsList
+        , FUN = is.list
+        , FUN.VALUE = logical(1)
+    ))
+    , msg = "Not all elements of exhibitsList is a list."
+)
+
+assertthat::assert_that(
+    all(vapply(
+        X = exhibitsList
+        , FUN = function(exh) {
+            setequal(names(exh), c("package_name", "report_url", "image_url"))
+        }
+        , FUN.VALUE = logical(1)
+    ))
+    , msg = "Not all elements of exhibitsList have 'package_name', 'report_url', 'image_url'"
+)
+
+assertthat::assert_that(
+    all(vapply(
+        X = exhibitsList
+        , FUN = function(exh) {
+            all(vapply(
+                X = exh
+                , FUN = is.character
+                , FUN.VALUE = logical(1)
+            ))
+        }
+        , FUN.VALUE = logical(1)
+    ))
+    , msg = "Some exhibit(s) have non-character values for 'package_name', 'report_url', or 'image_url'"
+)
+
 # Sort exhibits alphabetically by name
 exhibitsList <- exhibitsList[order(
     # Pull out package_name to use with order to reorder
@@ -67,7 +102,7 @@ exhibitsList <- exhibitsList[order(
 
 # Template for one cell in exhibit table, for use with glue
 cellTemplate <- '
-<td width="33%">{package_name}<br>
+<td width="33%" style="text-align:center">{package_name}<br>
     <a href="{report_url}">
         <img width="300" src="{image_url}">
     </a>


### PR DESCRIPTION
This PR makes two changes:
- Use R code in the vignette rmarkdown to generate the HTML for the table from a list. 
    - This adds `glue` as a dependency for being able to run the pkgdown script
- Centers the package name in each cell of the table