### PR TITLE
Update pkgnet_build_gallery.R

### DIFF
--- a/pkgnet_build_gallery.R
+++ b/pkgnet_build_gallery.R
@@ -13,6 +13,7 @@ library(knitr)
 
 #### Default pkgdown build ####
 
+pkgdown::clean_site(force = TRUE)
 pkgdown::build_articles(lazy = FALSE)
 
 


### PR DESCRIPTION
As recommended in error statements from pkgdown, running pkgdown::clean_site(force = TRUE) before building articles.